### PR TITLE
FIX: import error

### DIFF
--- a/inc/admin/settings/class-lp-settings-general.php
+++ b/inc/admin/settings/class-lp-settings-general.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once('abstract-settings-page.php');
 /**
  * Class LP_Settings_General
  *


### PR DESCRIPTION
The import statement has to be included to ensure automated activation
through wp-cli plugin